### PR TITLE
Fix pofiles discovering logic in '--modified' option when files are renamed.

### DIFF
--- a/powrap/powrap.py
+++ b/powrap/powrap.py
@@ -104,14 +104,14 @@ def main():
     """
     args = parse_args()
     if args.modified:
-        git_status = check_output(["git", "status", "--porcelain"], encoding="utf-8")
+        git_status = check_output(["git", "status", "--porcelain", "--no-renames"], encoding="utf-8")
         git_status_lines = [
             line.split(maxsplit=2) for line in git_status.split("\n") if line
         ]
         args.po_files.extend(
             Path(filename)
             for status, filename in git_status_lines
-            if filename.endswith(".po")
+            if filename.endswith(".po") and status != "D"
         )
     if not args.po_files:
         print("Nothing to do, exiting.")

--- a/powrap/powrap.py
+++ b/powrap/powrap.py
@@ -16,8 +16,7 @@ from powrap import __version__
 
 
 def check_style(po_files: Iterable[str], no_wrap=False, quiet=False):
-    """Check style of given po_files
-    """
+    """Check style of given po_files"""
     to_fix = []
     for po_path in tqdm(po_files, desc="Checking wrapping of po files", disable=quiet):
         with open(po_path, encoding="UTF-8") as po_file:
@@ -34,8 +33,7 @@ def check_style(po_files: Iterable[str], no_wrap=False, quiet=False):
 
 
 def fix_style(po_files, no_wrap=False, quiet=False):
-    """Fix style of given po_files.
-    """
+    """Fix style of given po_files."""
     for po_path in tqdm(po_files, desc="Fixing wrapping of po files", disable=quiet):
         with open(po_path, encoding="UTF-8") as po_file:
             po_content = po_file.read()
@@ -46,8 +44,7 @@ def fix_style(po_files, no_wrap=False, quiet=False):
 
 
 def parse_args():
-    """Parse powrap command line arguments.
-    """
+    """Parse powrap command line arguments."""
 
     def path(path_str):
         path_obj = Path(path_str)
@@ -100,11 +97,12 @@ def parse_args():
 
 
 def main():
-    """Powrap main entrypoint (parsing command line and all).
-    """
+    """Powrap main entrypoint (parsing command line and all)."""
     args = parse_args()
     if args.modified:
-        git_status = check_output(["git", "status", "--porcelain", "--no-renames"], encoding="utf-8")
+        git_status = check_output(
+            ["git", "status", "--porcelain", "--no-renames"], encoding="utf-8"
+        )
         git_status_lines = [
             line.split(maxsplit=2) for line in git_status.split("\n") if line
         ]


### PR DESCRIPTION
I'm getting this error when I've renamed a file running `powrap --modified`:

```
Traceback (most recent call last):
  File "/.../python-docs-es/venv/bin/powrap", line 33, in <module>
    sys.exit(load_entry_point('powrap', 'console_scripts', 'powrap')())
  File "/.../python-docs-es/venv/src/powrap/powrap/powrap.py", line 111, in main
    args.po_files.extend(
  File "/.../python-docs-es/venv/src/powrap/powrap/powrap.py", line 113, in <genexpr>
    for status, filename in git_status_lines
ValueError: too many values to unpack (expected 2)
```

It seems that the error is coming from the extension of `args.pofiles` when are renamed files, because the output of `git status --porcelain` when there are renamed files is like:

```
M  .pre-commit-config.yaml
 M cpython
R  dictionaries/library_http_cookies.txt -> dictionaries/library_http.cookies.txt
M  library/http.cookies.po
M  requirements.txt
```

And the split in `git_status_lines` takes the value:

```python
[['M', '.pre-commit-config.yaml'], ['M', 'cpython'], ['R', 'dictionaries/library_http_cookies.txt', '-> dictionaries/library_http.cookies.txt'], ['M', 'library/http.cookies.po'], ['M', 'requirements.txt']]
```

and here is the error.

---

The workaround which I opted to is to add `--no-renames` option to `git` command. The output in the example above is:

```
M  .pre-commit-config.yaml
 M cpython
A  dictionaries/library_http.cookies.txt
D  dictionaries/library_http_cookies.txt
M  library/http.cookies.po
M  requirements.txt
```

and ignore all files with status `D`.