### PR TITLE
Remove unnecessary option '--modified' from pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
     entry: powrap
     language: python
     files: \.po$
-    args: ['--modified', '--quiet']
+    args: ['--quiet']


### PR DESCRIPTION
`pre-commit`, as default, run their hooks using `git diff` to check what files must be affected by the hook. Also has an option [`--files`](https://pre-commit.com/#pre-commit-run) that could interfere with `--modified` option.